### PR TITLE
Fixed a bug in LambdaManager.js causing a TooManyRequestsException exception due to incorrect state checking

### DIFF
--- a/lib/LambdaManager.js
+++ b/lib/LambdaManager.js
@@ -21,7 +21,7 @@ LambdaManager.prototype.PublishNewVersion = async function(functionName, bucket,
       }
       await new Promise(resolve => setTimeout(resolve, 1000));
     } catch (error) {
-      console.error("Failed checking lambda status while publishing a new version", e);
+      console.error('Failed checking lambda status while publishing a new version', error);
     }
   }
   return result;

--- a/lib/LambdaManager.js
+++ b/lib/LambdaManager.js
@@ -21,7 +21,7 @@ LambdaManager.prototype.PublishNewVersion = async function(functionName, bucket,
       }
       await new Promise(resolve => setTimeout(resolve, 1000));
     } catch (error) {
-      //
+      console.error(e);
     }
   }
   return result;

--- a/lib/LambdaManager.js
+++ b/lib/LambdaManager.js
@@ -21,7 +21,7 @@ LambdaManager.prototype.PublishNewVersion = async function(functionName, bucket,
       }
       await new Promise(resolve => setTimeout(resolve, 1000));
     } catch (error) {
-      console.error(e);
+      console.error("Failed checking lambda status while publishing a new version", e);
     }
   }
   return result;

--- a/lib/LambdaManager.js
+++ b/lib/LambdaManager.js
@@ -16,7 +16,7 @@ LambdaManager.prototype.PublishNewVersion = async function(functionName, bucket,
   for (let iterationCount = 0; iterationCount < 60; iterationCount++) {
     try {
       const waiterResult = await this.LambdaFactory.waitFor('functionActive', { FunctionName: `${functionName}:${result.Version}` }).promise();
-      if (waiterResult.Configuration.State === 'Active') {
+      if (waiterResult.State === 'Active') {
         break;
       }
       await new Promise(resolve => setTimeout(resolve, 1000));


### PR DESCRIPTION
Check the docs [here](https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/Lambda.html#waitFor-property), there is a different response type for `functionActive` vs `functionExists`. `functionActive` does not have a wrapping `Configuration` element